### PR TITLE
Fix nickname escaping

### DIFF
--- a/TS3Hook/Ts3Plugin.cpp
+++ b/TS3Hook/Ts3Plugin.cpp
@@ -5,7 +5,7 @@
 #define PLUGIN_API_VERSION 22
 
 const char* ts3plugin_name() { return "TS3Hook"; }
-const char* ts3plugin_version() { return "1.2.1"; }
+const char* ts3plugin_version() { return "1.2"; }
 
 int ts3plugin_apiVersion() {
 	int target = -1;

--- a/TS3Hook/Ts3Plugin.cpp
+++ b/TS3Hook/Ts3Plugin.cpp
@@ -5,7 +5,7 @@
 #define PLUGIN_API_VERSION 22
 
 const char* ts3plugin_name() { return "TS3Hook"; }
-const char* ts3plugin_version() { return "1.1.1"; }
+const char* ts3plugin_version() { return "1.2"; }
 
 int ts3plugin_apiVersion() {
 	int target = -1;

--- a/TS3Hook/Ts3Plugin.cpp
+++ b/TS3Hook/Ts3Plugin.cpp
@@ -5,7 +5,7 @@
 #define PLUGIN_API_VERSION 22
 
 const char* ts3plugin_name() { return "TS3Hook"; }
-const char* ts3plugin_version() { return "1.2"; }
+const char* ts3plugin_version() { return "1.2.1"; }
 
 int ts3plugin_apiVersion() {
 	int target = -1;

--- a/TS3Hook/dllmain.cpp
+++ b/TS3Hook/dllmain.cpp
@@ -298,6 +298,7 @@ void STD_DECL log_out_packet(char* packet, int length)
 		}
 		else if (nickname_length > 3 && length_difference + nickname_length >= 0) {
 			nickname = in_str.substr(client_nickname + 16, (client_ver - client_nickname - 17));
+			replace_all(nickname, R"(\s)", " ");
 			nick_change_needed = true;
 			in_str.erase(client_nickname + 16, (client_ver - client_nickname - 17));
 			in_str.insert(client_nickname + 16, random_string(3));


### PR DESCRIPTION
I actually forgot about this, spaces were represented as \s instead of actual white space